### PR TITLE
Added support for supplying custom Source AL2 EKS AMI ID

### DIFF
--- a/amazon-eks-al2.pkr.hcl
+++ b/amazon-eks-al2.pkr.hcl
@@ -198,7 +198,7 @@ source "amazon-ebs" "this" {
   session_manager_port    = var.session_manager_port
   shutdown_behavior       = var.shutdown_behavior
   skip_profile_validation = var.skip_profile_validation
-  source_ami              = data.amazon-parameterstore.this.value
+  source_ami              = var.custom_al2_eks_source_ami == "" ? data.amazon-parameterstore.this.value : var.custom_al2_eks_source_ami
 
   dynamic "subnet_filter" {
     for_each = length(var.subnet_filter) > 0 ? var.subnet_filter : []

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -692,3 +692,8 @@ variable "shell_provisioner3" {
   description = "Values passed to the third/last shell provisioner"
   default     = {}
 }
+
+variable "custom_al2_eks_source_ami" {
+  description = "Custom AL2 EKS AMI ID to be used instead of Standard AMI"
+  default = ""
+}


### PR DESCRIPTION
## **User description**
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->


___

## **Type**
enhancement


___

## **Description**
- Introduced the ability to specify a custom Amazon Linux 2 (AL2) EKS AMI ID through a new variable `custom_al2_eks_source_ami`. If not specified, the build process defaults to using the standard AMI.
- This enhancement allows for greater flexibility in the AMI selection process during the EKS cluster setup.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>amazon-eks-al2.pkr.hcl</strong><dd><code>Support Custom AL2 EKS AMI ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
amazon-eks-al2.pkr.hcl

<li>Added support for using a custom Amazon Linux 2 (AL2) EKS AMI ID if <br>provided, otherwise defaults to the standard AMI.<br>


</details>
    

  </td>
  <td><a href="https:/duplocloud/amazon-eks-custom-amis/pull/3/files#diff-6bb02d0c6b933bb3019a15c9d5a2ed4f5cd13f53288da5356567634895cf13e8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>variables.pkr.hcl</strong><dd><code>New Variable for Custom AL2 EKS AMI ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
variables.pkr.hcl

<li>Introduced a new variable <code>custom_al2_eks_source_ami</code> to specify a <br>custom AL2 EKS AMI ID.<br>


</details>
    

  </td>
  <td><a href="https:/duplocloud/amazon-eks-custom-amis/pull/3/files#diff-e8c6c49cd684587f1da8adf4e1a33716c3e08fb1f9d95ef15d896e54559af88a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

